### PR TITLE
Align Readme files with documentation on avd.schoolyear.com

### DIFF
--- a/images/office365/README.md
+++ b/images/office365/README.md
@@ -3,7 +3,7 @@
 ## Image package
 
 ```cmd
-avd-cli image package \
+avdcli image package \
     -l default_layers/common_config \
     -l default_layers/clean \
     -l default_layers/vdot \
@@ -18,10 +18,10 @@ avd-cli image package \
 ## Package deployment
 
 ```cmd
-avd-cli package deploy \
+avdcli package deploy \
     -n office365 \
     -s <<azure subscription id>> \
-    -rg imagebuilder \
+    -rg imagebuilding \
     -r "https://<storageaccount>.blob.core.windows.net/<containername>" \
     --start
 ```

--- a/images/office365/README.md
+++ b/images/office365/README.md
@@ -23,5 +23,6 @@ avdcli package deploy \
     -s <<azure subscription id>> \
     -rg imagebuilding \
     -r "https://<storageaccount>.blob.core.windows.net/<containername>" \
+    -dto out/resolved_template.json \
     --start
 ```

--- a/images/rstudio/README.md
+++ b/images/rstudio/README.md
@@ -54,7 +54,7 @@ The `rstudio` folder consists of the following subfolders/files
 ## Image package
 
 ```cmd
-avd-cli image package \
+avdcli image package \
     -l default_layers/common_config \
     -l default_layers/clean \
     -l default_layers/vdot \
@@ -68,11 +68,11 @@ avd-cli image package \
 ## Package deployment
 
 ```cmd
-avd-cli.exe package deploy \
+avdcli package deploy \
     -n rstudio \
     -s <<azure subscription id>> \
-    -rg imagebuilder \
+    -rg imagebuilding \
     -r "https://<storageaccount>.blob.core.windows.net/<containername>" \
-    -dto out/deployment_template.json
+    -dto out/resolved_template.json
     --start
 ```


### PR DESCRIPTION
The path variable for the avdcli and the resource group has different names in the readme vs the documentation on avd.schoolyear.com.

avd-cli -> avdcli
imagebuilder -> imagebuilding